### PR TITLE
Modified KeyCombinations to support the Command key on Apple keyboards.

### DIFF
--- a/src/main/java/simulizer/ui/components/MainMenuBar.java
+++ b/src/main/java/simulizer/ui/components/MainMenuBar.java
@@ -83,7 +83,7 @@ public class MainMenuBar extends MenuBar {
 			if (!wm.getCPU().isRunning())
 				CurrentFile.newFile();
 		});
-		newItem.setAccelerator(new KeyCodeCombination(KeyCode.N, KeyCombination.CONTROL_DOWN));
+		newItem.setAccelerator(new KeyCodeCombination(KeyCode.N, KeyCombination.SHORTCUT_DOWN));
 
 		// | |-- Open
 		MenuItem loadItem = new MenuItem("Open");
@@ -95,7 +95,7 @@ public class MainMenuBar extends MenuBar {
 					CurrentFile.loadFile(f);
 			}
 		});
-		loadItem.setAccelerator(new KeyCodeCombination(KeyCode.O, KeyCombination.CONTROL_DOWN));
+		loadItem.setAccelerator(new KeyCodeCombination(KeyCode.O, KeyCombination.SHORTCUT_DOWN));
 
 		// | |-- Save
 		MenuItem saveItem = new MenuItem("Save");
@@ -104,7 +104,7 @@ public class MainMenuBar extends MenuBar {
 			if (!wm.getCPU().isRunning())
 				CurrentFile.promptSave();
 		});
-		saveItem.setAccelerator(new KeyCodeCombination(KeyCode.S, KeyCombination.CONTROL_DOWN));
+		saveItem.setAccelerator(new KeyCodeCombination(KeyCode.S, KeyCombination.SHORTCUT_DOWN));
 
 		// | |-- Save As
 		MenuItem saveAsItem = new MenuItem("Save As...");
@@ -121,7 +121,7 @@ public class MainMenuBar extends MenuBar {
 			if (!wm.getCPU().isRunning())
 				CurrentFile.reloadFile();
 		});
-		reloadItem.setAccelerator(new KeyCodeCombination(KeyCode.R, KeyCombination.CONTROL_DOWN));
+		reloadItem.setAccelerator(new KeyCodeCombination(KeyCode.R, KeyCombination.SHORTCUT_DOWN));
 
 		// | |-- Options
 		MenuItem optionsItem = new MenuItem("Options");
@@ -159,38 +159,38 @@ public class MainMenuBar extends MenuBar {
 
 		MenuItem cut = new MenuItem("Cut");
 		cut.setDisable(allowDisabling && (e == null || e.getMode() == Editor.Mode.EXECUTE_MODE));
-		cut.setAccelerator(new KeyCodeCombination(KeyCode.X, KeyCombination.CONTROL_DOWN));
+		cut.setAccelerator(new KeyCodeCombination(KeyCode.X, KeyCombination.SHORTCUT_DOWN));
 		cut.setOnAction((a) -> passToEditor(KeyCode.X));
 
 		MenuItem copy = new MenuItem("Copy");
 		copy.setDisable(allowDisabling && (e == null || e.getMode() == Editor.Mode.EXECUTE_MODE));
-		copy.setAccelerator(new KeyCodeCombination(KeyCode.C, KeyCombination.CONTROL_DOWN));
+		copy.setAccelerator(new KeyCodeCombination(KeyCode.C, KeyCombination.SHORTCUT_DOWN));
 		copy.setOnAction((a) -> passToEditor(KeyCode.C));
 
 		MenuItem paste = new MenuItem("Paste");
 		paste.setDisable(allowDisabling && (e == null || e.getMode() == Editor.Mode.EXECUTE_MODE));
-		paste.setAccelerator(new KeyCodeCombination(KeyCode.V, KeyCombination.CONTROL_DOWN));
+		paste.setAccelerator(new KeyCodeCombination(KeyCode.V, KeyCombination.SHORTCUT_DOWN));
 		paste.setOnAction((a) -> passToEditor(KeyCode.V));
 
 		MenuItem find = new MenuItem("Find");
-		find.setAccelerator(new KeyCodeCombination(KeyCode.F, KeyCombination.CONTROL_DOWN));
+		find.setAccelerator(new KeyCodeCombination(KeyCode.F, KeyCombination.SHORTCUT_DOWN));
 		find.setOnAction((a) -> passToEditor(KeyCode.F));
 
 		MenuItem gotoL = new MenuItem("Go To Line");
-		gotoL.setAccelerator(new KeyCodeCombination(KeyCode.G, KeyCombination.CONTROL_DOWN));
+		gotoL.setAccelerator(new KeyCodeCombination(KeyCode.G, KeyCombination.SHORTCUT_DOWN));
 		gotoL.setOnAction((a) -> passToEditor(KeyCode.G));
 
 		MenuItem insertBreakpoint = new MenuItem("Insert Breakpoint");
 		insertBreakpoint.setDisable(allowDisabling && (e == null || e.getMode() == Editor.Mode.EXECUTE_MODE));
-		insertBreakpoint.setAccelerator(new KeyCodeCombination(KeyCode.B, KeyCombination.CONTROL_DOWN));
+		insertBreakpoint.setAccelerator(new KeyCodeCombination(KeyCode.B, KeyCombination.SHORTCUT_DOWN));
 		insertBreakpoint.setOnAction((a) -> passToEditor(KeyCode.B));
 
 		MenuItem fontInc = new MenuItem("Increase Font Size");
-		fontInc.setAccelerator(new KeyCodeCombination(KeyCode.PLUS, KeyCombination.CONTROL_DOWN));
+		fontInc.setAccelerator(new KeyCodeCombination(KeyCode.PLUS, KeyCombination.SHORTCUT_DOWN));
 		fontInc.setOnAction((a) -> passToEditor(KeyCode.PLUS));
 
 		MenuItem fontDec = new MenuItem("Decrease Font Size");
-		fontDec.setAccelerator(new KeyCodeCombination(KeyCode.MINUS, KeyCombination.CONTROL_DOWN));
+		fontDec.setAccelerator(new KeyCodeCombination(KeyCode.MINUS, KeyCombination.SHORTCUT_DOWN));
 		fontDec.setOnAction((a) -> passToEditor(KeyCode.MINUS));
 
 		CheckMenuItem wordWrap = new CheckMenuItem("Toggle Word Wrap");

--- a/src/main/java/simulizer/ui/windows/Editor.java
+++ b/src/main/java/simulizer/ui/windows/Editor.java
@@ -51,21 +51,21 @@ public class Editor extends InternalWindow {
 	private volatile boolean contentIsModified; // changes have been made in the editor since loading
 
 	// handle key combos for copy and paste
-	final static private KeyCombination C_c = new KeyCodeCombination(KeyCode.C, KeyCombination.CONTROL_DOWN);
-	final static private KeyCombination C_x = new KeyCodeCombination(KeyCode.X, KeyCombination.CONTROL_DOWN);
-	final static private KeyCombination C_v = new KeyCodeCombination(KeyCode.V, KeyCombination.CONTROL_DOWN);
-	final static private KeyCombination C_b = new KeyCodeCombination(KeyCode.B, KeyCombination.CONTROL_DOWN);
-	final static private KeyCombination C_g = new KeyCodeCombination(KeyCode.G, KeyCombination.CONTROL_DOWN);
-	final static private KeyCombination C_f = new KeyCodeCombination(KeyCode.F, KeyCombination.CONTROL_DOWN);
+	final static private KeyCombination C_c = new KeyCodeCombination(KeyCode.C, KeyCombination.SHORTCUT_DOWN);
+	final static private KeyCombination C_x = new KeyCodeCombination(KeyCode.X, KeyCombination.SHORTCUT_DOWN);
+	final static private KeyCombination C_v = new KeyCodeCombination(KeyCode.V, KeyCombination.SHORTCUT_DOWN);
+	final static private KeyCombination C_b = new KeyCodeCombination(KeyCode.B, KeyCombination.SHORTCUT_DOWN);
+	final static private KeyCombination C_g = new KeyCodeCombination(KeyCode.G, KeyCombination.SHORTCUT_DOWN);
+	final static private KeyCombination C_f = new KeyCodeCombination(KeyCode.F, KeyCombination.SHORTCUT_DOWN);
 
 	// for Ctrl plus with each different plus key on the keyboard
-	final static private KeyCombination C_add = new KeyCodeCombination(KeyCode.ADD, KeyCombination.CONTROL_DOWN);
-	final static private KeyCombination C_plus = new KeyCodeCombination(KeyCode.PLUS, KeyCombination.CONTROL_DOWN); // Caps lock + =
-	final static private KeyCombination C_eq = new KeyCodeCombination(KeyCode.EQUALS, KeyCombination.CONTROL_DOWN);
-	final static private KeyCombination C_S_eq = new KeyCodeCombination(KeyCode.EQUALS, KeyCombination.CONTROL_DOWN, KeyCombination.SHIFT_DOWN);
+	final static private KeyCombination C_add = new KeyCodeCombination(KeyCode.ADD, KeyCombination.SHORTCUT_DOWN);
+	final static private KeyCombination C_plus = new KeyCodeCombination(KeyCode.PLUS, KeyCombination.SHORTCUT_DOWN); // Caps lock + =
+	final static private KeyCombination C_eq = new KeyCodeCombination(KeyCode.EQUALS, KeyCombination.SHORTCUT_DOWN);
+	final static private KeyCombination C_S_eq = new KeyCodeCombination(KeyCode.EQUALS, KeyCombination.SHORTCUT_DOWN, KeyCombination.SHIFT_DOWN);
 	// for Ctrl minus with each different minus key on the keyboard
-	final static private KeyCombination C_minus = new KeyCodeCombination(KeyCode.MINUS, KeyCombination.CONTROL_DOWN);
-	final static private KeyCombination C_subtract = new KeyCodeCombination(KeyCode.SUBTRACT, KeyCombination.CONTROL_DOWN);
+	final static private KeyCombination C_minus = new KeyCodeCombination(KeyCode.MINUS, KeyCombination.SHORTCUT_DOWN);
+	final static private KeyCombination C_subtract = new KeyCodeCombination(KeyCode.SUBTRACT, KeyCombination.SHORTCUT_DOWN);
 
 	// references to javascript objects
 	private SafeJSObject jsWindow;


### PR DESCRIPTION
Since `CONTROL_DOWN` does not correspond to the Command key on Apple keyboards, but rather the actual Control key, using `SHORTCUT_DOWN` is the *correct* way of ensuring cross-compatibility across Apple and non-Apple keyboard layouts.

You can read more about this [here](http://docs.oracle.com/javase/8/javafx/api/javafx/scene/input/KeyCombination.html).